### PR TITLE
Update CellCounter.java loadMarkers function

### DIFF
--- a/src/main/java/CellCounter.java
+++ b/src/main/java/CellCounter.java
@@ -815,6 +815,21 @@ public class CellCounter extends JFrame implements ActionListener, ItemListener
 				}
 			}
 			
+			// Adds radio buttons if too few initialized.
+			while (dynRadioVector.size() < typeVector.size()) {
+				final int i = dynRadioVector.size() + 1;
+				dynGrid.setRows(i);
+				final JRadioButton jrButton = new JRadioButton("Type " + i);
+				jrButton.setActionCommand(TYPE_COMMAND_PREFIX + i);
+				jrButton.addActionListener(this);
+				dynRadioVector.add(jrButton);
+				radioGrp.add(jrButton);
+				dynTxtPanel.add(makeDynamicTextArea());
+				dynButtonPanel.add(jrButton);
+				typeVector.get(index);
+				validateLayout();
+			}
+			
 			// Sets radio button names to loaded names
 			final ListIterator<CellCntrMarkerVector> it = typeVector.listIterator();
 			while (it.hasNext()) {


### PR DESCRIPTION
Adding a block to add radio buttons up to loaded typeVector size. Fixes an issue where having less radio buttons than specified in loaded XML file will crash the program.